### PR TITLE
Truncated description returns nothing if does not exist

### DIFF
--- a/models/community/Publication.js
+++ b/models/community/Publication.js
@@ -134,6 +134,8 @@ Publication.schema.virtual('title.trunc').get(function() {
 })
 
 Publication.schema.virtual('description.trunc').get(function() {
+  if (!this.description) return
+
   var truncated = this.description
 
   if (truncated.length > 121) {


### PR DESCRIPTION
Urgent bug fix for: Clicking the List view in Eresources returns an error.